### PR TITLE
Use Nginx to serve production instead of webpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 - Add dependabot monitoring to repository
+- Make Dockerfile serve from Nginx instead of webpack serve to improve performance
 
 ## [1.0.7] - 2021-12-08
 

--- a/webui/.dockerignore
+++ b/webui/.dockerignore
@@ -1,0 +1,11 @@
+# Items that don't need to be in a Docker image.
+# Anything not used by the build system should go here.
+Dockerfile
+.dockerignore
+.gitignore
+README.md
+
+# Artifacts that will be built during image creation.
+# This should contain all files created during `npm run build`.
+build
+node_modules

--- a/webui/Dockerfile
+++ b/webui/Dockerfile
@@ -1,8 +1,14 @@
-FROM node:alpine
+FROM node:alpine AS builder
 
 COPY package.json yarn.lock ./
 RUN yarn install && yarn global add webpack
-COPY . ./webui
-WORKDIR /webui
-EXPOSE 8080
-CMD ["yarn", "run", "build"]
+COPY . ./app
+WORKDIR /app
+RUN yarn build
+
+# production environment
+FROM nginx:stable-alpine
+COPY --from=builder /app/dist /usr/share/nginx/html
+COPY --from=builder /app/nginx/nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/webui/nginx/nginx.conf
+++ b/webui/nginx/nginx.conf
@@ -1,0 +1,8 @@
+server {
+    listen 80;
+    location / {
+        root /usr/share/nginx/html;
+        index index.html index.htm;
+        try_files $uri $uri/ /index.html =404;
+    }
+}

--- a/webui/package.json
+++ b/webui/package.json
@@ -21,8 +21,7 @@
   },
   "scripts": {
     "start": "NODE_ENV=development webpack serve --history-api-fallback",
-    "build": "NODE_ENV=production webpack serve --no-web-socket-server --history-api-fallback",
-    "predeploy": "npm run build",
+    "build": "NODE_ENV=production webpack build",
     "deploy": "gh-pages -d dist"
   },
   "dependencies": {


### PR DESCRIPTION
Currently, the Docker image is using `webpack` to serve the UI, but this isn't very good when visitor count increases due to added load.

This PR makes changes to build the static files when we create the container, and then serve those compiled files using Nginx.

Development `yarn start` will remain untouched - this only relates to the Docker environment.