### PR TITLE
Allow default port to be defined on build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 - Add dependabot monitoring to repository
+- Allow default port to be defined as an environment variable
 
 ## [1.0.7] - 2021-12-08
 

--- a/webui/Dockerfile
+++ b/webui/Dockerfile
@@ -1,5 +1,9 @@
 FROM node:alpine
 
+# ALlows the user to define a default port to populate the UI.
+# Pass a desired value in your docker run/compose environment
+ENV DEFAULT_PORT=$DEFAULT_PORT
+
 COPY package.json yarn.lock ./
 RUN yarn install && yarn global add webpack
 COPY . ./webui

--- a/webui/Dockerfile
+++ b/webui/Dockerfile
@@ -2,6 +2,7 @@ FROM node:alpine AS builder
 
 # ALlows the user to define a default port to populate the UI.
 # Pass a desired value in your docker run/compose environment
+ARG DEFAULT_PORT
 ENV DEFAULT_PORT=$DEFAULT_PORT
 
 COPY package.json yarn.lock ./

--- a/webui/src/pages/HomePage.js
+++ b/webui/src/pages/HomePage.js
@@ -16,7 +16,7 @@ export class HomePage extends Component {
             portError: "",
             showResults: false,
             host: "",
-            ports: "",
+            ports: parseInt(process.env.DEFAULT_PORT),
             results: [],
             msg: ""
         };
@@ -139,7 +139,7 @@ export class HomePage extends Component {
                     </div>
                     <div className="input-group ports-group">
                         <div className="form-group">
-                            <input className="input" type="number" placeholder="Port" value={this.state.value} onChange={this.portChange} onKeyUp={this.portChange}/>
+                            <input className="input" type="number" placeholder="Port" value={this.state.ports} onChange={this.portChange} onKeyUp={this.portChange}/>
                         </div>
                         { this.state.portError ? <span className="form-error">{this.state.portError}</span> : null }
                     </div>

--- a/webui/webpack.config.js
+++ b/webui/webpack.config.js
@@ -3,6 +3,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const TerserWebpackPlugin = require('terser-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+const webpack = require('webpack');
 
 const prod = process.env.NODE_ENV === 'production';
 
@@ -73,6 +74,9 @@ module.exports = {
     ],
   },
   plugins: [
+    new webpack.DefinePlugin({
+      'process.env.DEFAULT_PORT': JSON.stringify(process.env.DEFAULT_PORT) || null
+    }),
     new HtmlWebpackPlugin({
       hash: true,
       template: 'public/index.html',


### PR DESCRIPTION
This PR resolves https://github.com/dsgnr/portchecker.io/issues/6 where we would like to define a default port to be populated on page load.

This has been added as an environment variable which is compiled at build time.

For example, building the container with `DOCKER_BUILDKIT=0 docker build . -t port_arg --build-arg DEFAULT_PORT=443` will allow the port to be defined by the user and compiled into the static HTML files served by Nginx during `yarn build`.

`yarn start` for development purposes does not use Nginx and is compiled on the fly as normal, so this can be defined with a simple export when the pages are compiled.
