### PR TITLE
Separate dev and prod environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,8 @@ cython_debug/
 .DS_Store
 webui/node_modules
 k8s.yml
+
+# Elastic Beanstalk Files
+.elasticbeanstalk/*
+!.elasticbeanstalk/*.cfg.yml
+!.elasticbeanstalk/*.global.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## [1.0.8] - 2021-12-10
 
 - Add dependabot monitoring to repository
 - Allow default port to be defined as an environment variable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - Add dependabot monitoring to repository
 - Allow default port to be defined as an environment variable
 - Make Dockerfile serve from Nginx instead of webpack serve to improve performance
+- Separate development and production environments and add docker-compose files
 
 ## [1.0.7] - 2021-12-08
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ FROM node:alpine AS builder
 ARG DEFAULT_PORT
 ENV DEFAULT_PORT=$DEFAULT_PORT
 
-COPY package.json yarn.lock ./
+COPY webui/package.json webui/yarn.lock ./
 RUN yarn install && yarn global add webpack
-COPY . ./app
+COPY ./webui ./app
 WORKDIR /app
 RUN yarn build
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,12 @@
+FROM node:alpine
+
+# ALlows the user to define a default port to populate the UI.
+# Pass a desired value in your docker run/compose environment
+ARG DEFAULT_PORT
+ENV DEFAULT_PORT=$DEFAULT_PORT
+
+COPY webui/package.json webui/yarn.lock ./
+RUN yarn install && yarn global add webpack
+COPY ./webui ./app
+WORKDIR /app
+CMD ["yarn", "start"]

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,14 @@
+---
+version: "3.8"
+services:
+  portchecker-dev:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    container_name: portcheckerio-dev
+    environment:
+      - DEFAULT_PORT=
+    volumes:
+      - ./webui:/app
+    ports:
+      - 8080:8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+---
+version: "3.8"
+services:
+  portchecker:
+    image: dsgnr/portcheckerio-ui:latest
+    pull_policy: always
+    container_name: portcheckerio
+    ports:
+      - 80:80
+    restart: unless-stopped

--- a/webui/.gitignore
+++ b/webui/.gitignore
@@ -1,8 +1,3 @@
 .idea
 dist
 node_modules
-
-# Elastic Beanstalk Files
-.elasticbeanstalk/*
-!.elasticbeanstalk/*.cfg.yml
-!.elasticbeanstalk/*.global.yml


### PR DESCRIPTION
Creates separate Dockerfiles and respective docker-compose files for development and production environments.

docker-compose-dev.yml will volume mount the webui directory, and use `webpack start` for live reloads, whereas production will pull the latest image from Docker Hub.

This is to pave the way for better CI/CD integration for this project and to facilitate better environment handling in AWS.