### PR TITLE
Fix undefined env variable in console log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.9] - 2021-12-10
+
+- Resolve console warning about undefined DEFAULT_PORT var in production
+
 ## [1.0.8] - 2021-12-10
 
 - Add dependabot monitoring to repository

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     image: dsgnr/portcheckerio-ui:latest
     pull_policy: always
     container_name: portcheckerio
+    environment:
+      - DEFAULT_PORT=
     ports:
       - 80:80
     restart: unless-stopped

--- a/webui/src/pages/HomePage.js
+++ b/webui/src/pages/HomePage.js
@@ -16,7 +16,7 @@ export class HomePage extends Component {
             portError: "",
             showResults: false,
             host: "",
-            ports: parseInt(process.env.DEFAULT_PORT),
+            ports: parseInt(process.env.DEFAULT_PORT) || "",
             results: [],
             msg: ""
         };

--- a/webui/webpack.config.js
+++ b/webui/webpack.config.js
@@ -75,7 +75,7 @@ module.exports = {
   },
   plugins: [
     new webpack.DefinePlugin({
-      'process.env.DEFAULT_PORT': JSON.stringify(process.env.DEFAULT_PORT) || null
+      'process.env.DEFAULT_PORT': process.env.DEFAULT_PORT || null
     }),
     new HtmlWebpackPlugin({
       hash: true,


### PR DESCRIPTION
Resolves an issue in production where the `DEFAULT_PORT` variable isn't set, so console log warns with `The specified value "NaN" cannot be parsed, or is out of range.`