### PR TITLE
Add google analytics to front-end

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -8,6 +8,7 @@ services:
     container_name: web
     environment:
       - DEFAULT_PORT=443
+      - GOOGLE_ANALYTICS=  # optional
     ports:
       - 8080:8080
   api:

--- a/frontend/web/src/index.html
+++ b/frontend/web/src/index.html
@@ -83,5 +83,16 @@
                 </div>
             </footer>
         </div>
+	<% if (htmlWebpackPlugin.options.GOOGLE_ANALYTICS){ %>
+            <!-- Google tag (gtag.js) -->
+            <script async src="https://www.googletagmanager.com/gtag/js?id=G-1EHNTH9860"></script>
+            <script>
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+
+                gtag('config', '<%= htmlWebpackPlugin.options.GOOGLE_ANALYTICS %>');
+            </script>
+	 <% } %>
     </body>
 </html>

--- a/frontend/web/webpack.config.js
+++ b/frontend/web/webpack.config.js
@@ -23,6 +23,7 @@ module.exports = {
                 collapseWhitespace: true,
             },
             DEFAULT_PORT: process.env.DEFAULT_PORT,
+            GOOGLE_ANALYTICS: process.env.GOOGLE_ANALYTICS,
         }),
 
         new MiniCssExtractPlugin({


### PR DESCRIPTION
This commit adds an optional Google Analytics variable to the front-end of portchecker.io. This is to aid with tracking web visits. Privacy is 
of upmost concern, so only tracking about referrals, location and visit duration is monitored
