### PR TITLE
Add Google Adsense verification meta tag

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -9,6 +9,7 @@ services:
     environment:
       - DEFAULT_PORT=443
       - GOOGLE_ANALYTICS=  # optional
+      - ADSENSE_VERIFICATION=  # optional
     ports:
       - 8080:8080
   api:

--- a/frontend/web/src/index.html
+++ b/frontend/web/src/index.html
@@ -94,5 +94,10 @@
                 gtag('config', '<%= htmlWebpackPlugin.options.GOOGLE_ANALYTICS %>');
             </script>
 	 <% } %>
+	<% if (htmlWebpackPlugin.options.ADSENSE_VERIFICATION){ %>
+            <meta name="google-adsense-account" content="<%= htmlWebpackPlugin.options.ADSENSE_VERIFICATION%>">
+	 <% } %>
+    </body>
+</html>
     </body>
 </html>

--- a/frontend/web/webpack.config.js
+++ b/frontend/web/webpack.config.js
@@ -24,6 +24,7 @@ module.exports = {
             },
             DEFAULT_PORT: process.env.DEFAULT_PORT,
             GOOGLE_ANALYTICS: process.env.GOOGLE_ANALYTICS,
+            ADSENSE_VERIFICATION: process.env.ADSENSE_VERIFICATION,
         }),
 
         new MiniCssExtractPlugin({


### PR DESCRIPTION
Adds an optional environment variable to the front-end to verify Google Adsense.

This project comes with associated costs, and as much as I hate ads, there is no other revenue stream for this project. The amount of traffic 
this project receives should generate enough in ad revenue to cover the web and domain costs of the project.
