### PR TITLE
GitHub action pytest

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,40 @@
+name: API Pytest
+
+on:
+  push:
+    paths:
+      - backend
+  pull_request:
+    paths:
+      - backend
+
+jobs:
+  pytest:
+    defaults:
+      run:
+        working-directory: backend
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: false
+          virtualenvs-in-project: false
+          installer-parallel: true
+
+      - name: Valiate poetry.lock
+        run: poetry check
+
+      - name: Install dependencies
+        run: poetry install --no-interaction
+
+      - name: Test
+        run: pytest tests

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -772,6 +772,23 @@ pluggy = ">=1.5,<2"
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-mock"
+version = "3.14.0"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0"},
+    {file = "pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f"},
+]
+
+[package.dependencies]
+pytest = ">=6.2.5"
+
+[package.extras]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
@@ -1212,4 +1229,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "8b4d4812a8ef6621014a483d75975dfce3945733424fa65a6d18092159b07bb8"
+content-hash = "c01c390fbf7c3169fe55b2977fed71134529e15ab333739efff5592a3073fe14"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -17,6 +17,7 @@ uvicorn = {extras = ["standard"], version = "0.32.0"}
 pylint = "^3.3.1"
 isort = "^5.13.2"
 pytest = "^8.3.3"
+pytest-mock = "^3.14.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,10 +1,10 @@
 [tool.poetry]
-name = "portchecker-api"
+name = "api"
 version = "2.0.0"
 description = "A simple API to query ports for hostnames or IP addresses"
 authors = ["dsgnr <email@danielhand.io>"]
 license = "GNU General Public License v3.0"
-readme = "README.md"
+readme = "../README.md"
 
 [tool.poetry.dependencies]
 python = "^3.12"


### PR DESCRIPTION
Adds GitHub Actions workflow for running Pytest on the API.
Also adds a missing `pytest-mock` dependency.

Continues work from https://github.com/dsgnr/portchecker.io/pull/244