### PR TITLE
Only run GitHub workflows once

### DIFF
--- a/.github/workflows/api-code-test.yml
+++ b/.github/workflows/api-code-test.yml
@@ -1,9 +1,6 @@
 name: API
 
 on:
-  push:
-    paths:
-      - backend/**
   pull_request:
     paths:
       - backend/**


### PR DESCRIPTION
Fixes an issue where the workflow would run twice for a newly opened PR.
