### PR TITLE
Bump release 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.1.0] - 2024-11-08
+- Bump gunicorn from 22.0.0 to 23.0.0
+- Adds more dependabot update rules
+- Improve documentation
+- Various exception handling improvements
+- Add Pytests to API
+- Enforce Pylint and Isort
+- Add GitHub Actions workflow for Isort, Pylint and Pytest
+- Deduplicate of application info
+- Add favicon to web
+
 ## [3.0.0] - 2024-11-05
 - Rewrites the API to migrate from FastAPI to [Litestar](https://litestar.dev/).
 - This also migrates the documentation from Swagger to [Scalar](https://github.com/scalar/scalar).

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 package-mode = false
 name = "portchecker.io"
-version = "3.0.0"
+version = "3.1.0"
 description = """portchecker.io is an open-source API for checking port \
     availability on specified hostnames or IP addresses. \
     Ideal for developers and network admins, it helps troubleshoot network \


### PR DESCRIPTION
Bumps versions for releasing v3.1.0:

- Bump gunicorn from 22.0.0 to 23.0.0
- Adds more dependabot update rules
- Improve documentation
- Various exception handling improvements
- Add Pytests to API
- Enforce Pylint and Isort
- Add GitHub Actions workflow for Isort, Pylint and Pytest
- Deduplicate of application info
- Add favicon to web