### PR TITLE
Make DEFAULT_PORT environment variable work for static UI image"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 - Adds threading to `query_ipv4` method. Uses default worker value (CPU count).
   This will improve performance where there are more than one port that does not response,
   thus reaching the timeout limit.
+- Resolved an issue where the DEFAULT_PORT environment variable was not correctly updating
+  the value of the UI input field in the application.
+  The input field now reflects the specified default port value.
 
 ## [3.1.0] - 2024-11-08
 - Bump gunicorn from 22.0.0 to 23.0.0

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -7,7 +7,7 @@ services:
       dockerfile: Dockerfile.dev
     container_name: web
     environment:
-      - DEFAULT_PORT=443
+      - DEFAULT_PORT=443  # Populates a default port value to be populataed in the in the UI input
       - GOOGLE_ANALYTICS=  # optional
       - ADSENSE_VERIFICATION=  # optional
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: ghcr.io/dsgnr/portcheckerio-web:latest
     container_name: web
     environment:
-      - DEFAULT_PORT=443
+      - DEFAULT_PORT=443  # Populates a default port value to be populataed in the in the UI input
       - GOOGLE_ANALYTICS=  # optional
       - ADSENSE_VERIFICATION=  # optional
     ports:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:23-alpine3.19 as builder
-ARG GOOGLE_ANALYTICS ADSENSE_VERIFICATION
+ARG DEFAULT_PORT GOOGLE_ANALYTICS ADSENSE_VERIFICATION
+ENV DEFAULT_PORT=$DEFAULT_PORT
 ENV GOOGLE_ANALYTICS=$GOOGLE_ANALYTICS
 ENV ADSENSE_VERIFICATION=$ADSENSE_VERIFICATION
 
@@ -9,7 +10,10 @@ RUN yarn install && yarn build
 
 # production environment
 FROM nginx:stable-alpine-slim as web
+ARG DEFAULT_PORT
+ENV DEFAULT_PORT=$DEFAULT_PORT
 COPY --from=builder /app/dist /usr/share/nginx/html
+COPY ./entrypoint.sh /entrypoint.sh
 COPY ./nginx/nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]
+CMD ["sh", "/entrypoint.sh"]

--- a/frontend/entrypoint.sh
+++ b/frontend/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+set -e
+
+# `DEFAULT_PORT` is set by Webpack at container build time if the environment variable is provided.
+# If this variable is not set at that time (like for production images), we must modify the rendered HTML on container up.
+if [ -n "$DEFAULT_PORT" ]; then
+    sed -i -E "s/(<input[^>]*id=\"port\"[^>]*value=\")[^\"]*\"/\\1${DEFAULT_PORT}\"/" /usr/share/nginx/html/index.html
+    echo "Updated DEFAULT_PORT value to $DEFAULT_PORT."
+else
+    echo "DEFAULT_PORT is not set. No changes made."
+fi
+
+exec nginx -g "daemon off;"


### PR DESCRIPTION
The packaged UI image is simply serving static files via Nginx. Due to this, the `DEFAULT_PORT` environment variable would never update.
This PR fixes that by creating an entrypoint script which modifie the default value of the input field when the container starts.
