### PR TITLE
Use the new API endpoint in the UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Resolved an issue where the DEFAULT_PORT environment variable was not correctly updating
   the value of the UI input field in the application.
   The input field now reflects the specified default port value.
+- Updates the UI to no longer use the deprecated query endpoint.
 
 ## [3.1.0] - 2024-11-08
 - Bump gunicorn from 22.0.0 to 23.0.0

--- a/frontend/web/src/js/index.js
+++ b/frontend/web/src/js/index.js
@@ -83,7 +83,7 @@ function query_host() {
     pending_results(host);
     axios
         .post(
-            "/api/v1/query",
+            "/api/query",
             { host: host, ports: ports }
         )
         .then((response) => {


### PR DESCRIPTION
Updates the UI to no longer use the deprecated API route for queries.
