### PR TITLE
Add docs endpoint to webpack dev proxy

### DIFF
--- a/frontend/web/webpack.config.js
+++ b/frontend/web/webpack.config.js
@@ -41,7 +41,7 @@ module.exports = {
         port: 8080,
         proxy: [
             {
-                context: ['/api'],
+                context: ['/api', '/docs'],
                 target: 'http://api:8000',
             },
         ]


### PR DESCRIPTION
Adds the `/docs` endpoint to the Webpack Dev Server proxy
