### PR TITLE
Fix web container where volume mounts are used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.1.2] - 2024-11-18
+- Fixes a regression caused by [#258](https://github.com/dsgnr/portchecker.io/pull/258)
+  where the web container would fail to start if the index was overwritten by a custom volume mount.
+
 ## [3.1.1] - 2024-11-18
 - Fixes incorrect environment variable defaults in README
 - Adds threading to `query_ipv4` method. Uses default worker value (CPU count).

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 package-mode = false
 name = "portchecker.io"
-version = "3.1.1"
+version = "3.1.2"
 description = """portchecker.io is an open-source API for checking port \
     availability on specified hostnames or IP addresses. \
     Ideal for developers and network admins, it helps troubleshoot network \

--- a/frontend/entrypoint.sh
+++ b/frontend/entrypoint.sh
@@ -4,8 +4,11 @@ set -e
 # `DEFAULT_PORT` is set by Webpack at container build time if the environment variable is provided.
 # If this variable is not set at that time (like for production images), we must modify the rendered HTML on container up.
 if [ -n "$DEFAULT_PORT" ]; then
-    sed -i -E "s/(<input[^>]*id=\"port\"[^>]*value=\")[^\"]*\"/\\1${DEFAULT_PORT}\"/" /usr/share/nginx/html/index.html
-    echo "Updated DEFAULT_PORT value to $DEFAULT_PORT."
+    if sed -i -E "s/(<input[^>]*id=\"port\"[^>]*value=\")[^\"]*\"/\\1${DEFAULT_PORT}\"/" /usr/share/nginx/html/index.html; then
+        echo "Updated DEFAULT_PORT value to $DEFAULT_PORT."
+    else
+        echo "An error occurred when attempting to set the DEFAULT_PORT value."
+    fi
 else
     echo "DEFAULT_PORT is not set. No changes made."
 fi


### PR DESCRIPTION
Resolves https://github.com/dsgnr/portchecker.io/issues/265


Before:
~~~
Attaching to api, web
web  | sed: can't move '/usr/share/nginx/html/index.htmlPnFoaf' to '/usr/share/nginx/html/index.html': Resource busy
web exited with code 1
~~~

After:
~~~
Attaching to api, web
web  | sed: can't move '/usr/share/nginx/html/index.htmlPnlLIH' to '/usr/share/nginx/html/index.html': Resource busy
web  | An error occurred when attempting to set the DEFAULT_PORT value.
web  | 2024/11/18 17:50:23 [notice] 1#1: using the "epoll" event method
web  | 2024/11/18 17:50:23 [notice] 1#1: nginx/1.26.2
~~~