### PR TITLE
Docker improvements

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,5 +1,4 @@
 ---
-version: "3.8"
 services:
   web:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 ---
-version: "3.8"
 services:
   web:
     image: ghcr.io/dsgnr/portcheckerio-web:latest

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:23-alpine3.19 as builder
+FROM node:23-alpine3.19 AS builder
 ARG DEFAULT_PORT GOOGLE_ANALYTICS
 ENV DEFAULT_PORT=$DEFAULT_PORT
 ENV GOOGLE_ANALYTICS=$GOOGLE_ANALYTICS
@@ -8,7 +8,7 @@ WORKDIR /app
 RUN yarn install && yarn build
 
 # production environment
-FROM nginx:stable-alpine-slim as web
+FROM nginx:stable-alpine-slim AS web
 ARG DEFAULT_PORT
 ENV DEFAULT_PORT=$DEFAULT_PORT
 COPY --from=builder /app/dist /usr/share/nginx/html

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,11 +1,12 @@
-FROM node:23-alpine3.19 
+FROM node:23-alpine3.19
+ENV PATH=$PATH:$PWD/node_modules/.bin
 
 # ALlows the user to define a default port to populate the UI.
 # Pass a desired value in your docker run/compose environment
 ARG DEFAULT_PORT
 ENV DEFAULT_PORT=$DEFAULT_PORT
 
-COPY web/package.json ./
+COPY web/package.json web/yarn.lock ./
 RUN yarn install
 COPY ./web ./web
 WORKDIR /web


### PR DESCRIPTION
- Fixes:
  ~~~
   => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)                                           0.0s
   => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 11)                                          0.0s
  ~~~

- Fixes:
  ~~~
  WARN[0000] ~/portchecker.io/docker-compose-dev.yml: the attribute `version` is obsolete, it will be ignored, please. 
  remove it to avoid potential confusion
  ~~~

- Fixes an issue where webpack would raise `command not found` due to incorrect env path.
- Adds missing yarn.lock file to avoid incorrect package versions being installed.