### PR TITLE
Update image path for Ko-Fi

### DIFF
--- a/frontend/web/src/index.html
+++ b/frontend/web/src/index.html
@@ -104,10 +104,10 @@
                                     alt="DigitalOcean Referral Badge"
                                 />
                             </a>
-                            <a href="https://ko-fi.com/U7U3FUX17" target="_blank">
+                            <a href="https://ko-fi.com/dsgnr" target="_blank">
                                 <img
                                     height="36"
-                                    src="https://cdn.ko-fi.com/cdn/kofi3.png?v=3"
+                                    src="https://storage.ko-fi.com/cdn/kofi3.png"
                                     alt="Buy Me a Coffee at ko-fi.com"
                                 />
                             </a>


### PR DESCRIPTION
The image path for the Ko-Fi coffee link changed from `cdn.ko-fi.com` to `storage.ko-fi.com`. This caused the front-end to fail to load correctly.

Also updates the profile URL from the UID to user name.