### PR TITLE
Add datasource dropdown for Grafana dashboard

### DIFF
--- a/grafana/portchecker-grafana-dashboard.json
+++ b/grafana/portchecker-grafana-dashboard.json
@@ -70,6 +70,7 @@
   "graphTooltip": 0,
   "id": null,
   "links": [],
+  "liveNow": true,
   "panels": [
     {
       "datasource": {
@@ -769,8 +770,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -835,7 +835,18 @@
   "schemaVersion": 40,
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {},
+        "label": "Datasource",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
   },
   "time": {
     "from": "now-12h",
@@ -845,6 +856,6 @@
   "timezone": "",
   "title": "portchecker.io",
   "uid": "portcheckerio-monitoring",
-  "version": 12,
+  "version": 14,
   "weekStart": ""
 }


### PR DESCRIPTION
Adds missing datasource dropdown option which helps make the dashboard more portable for other Grafana instances.