### PR TITLE
Fix issue where localhost would resolve to ipv6 for healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     ports:
       - 8080:80
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-S", "http://localhost"]
+      test: ["CMD", "wget", "--spider", "-S", "http://127.0.0.1"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -28,7 +28,7 @@ services:
     ports:
       - 8000:8000
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-S", "http://localhost:8000/healthz"]
+      test: ["CMD", "wget", "--spider", "-S", "http://127.0.0.1:8000/healthz"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
Resolves #355.

In Alpine-based containers, localhost resolves to both IPv6 (::1) and IPv4 (127.0.0.1), with IPv6 listed first. This happens because Alpine uses musl libc, which prefers IPv6 and doesn’t support customising the order (via `/etc/gai.conf`).

``` sh
/ # getent ahosts localhost
::1             STREAM localhost
::1             DGRAM  localhost
127.0.0.1       STREAM localhost
127.0.0.1       DGRAM  localhost
```
Normally this wouldn’t be an issue, but Alpine’s wget comes from BusyBox: `BusyBox v1.37.0 (2025-01-17 18:12:01 UTC) multi-call binary`. Unlike GNU Wget, BusyBox’s version doesn’t try IPv4 if the IPv6 connection fails. So if nothing is listening on ::1, wget localhost just fails immediately:

``` sh
/ # wget localhost
Connecting to localhost ([::1]:80)
wget: can't connect to remote host: Connection refused
```
To avoid this, we now use 127.0.0.1 directly instead of localhost, which ensures wget hits the working IPv4 interface and doesn’t rely on fallback behaviour that BusyBox doesn’t support.

Also means we don't need to worry about installing different/more packages (like curl) to make the healthcheck work.