### PR TITLE
fix: add missing stage target in backend Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,7 +12,7 @@ COPY pyproject.toml poetry.lock ./
 
 RUN poetry install --only=main --no-root --no-cache
 
-FROM python:3.13-alpine3.23
+FROM python:3.13-alpine3.23 AS api
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \


### PR DESCRIPTION
Fixes an issue where tagged releases would fail to build due to a missing target stage. This is a regression from https://github.com/dsgnr/portchecker.io/pull/404
