### PR TITLE
Smoke testing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,22 @@ updates:
       interval: "monthly"
     commit-message:
       prefix: "[web] "
+    # Only raise version-update PRs for major and minor bumps.
+    # Security updates are unaffected by this ignore and will still be raised.
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
   - package-ecosystem: "pip"
     directory: "/backend"
     schedule:
       interval: "monthly"
     commit-message:
       prefix: "[api] "
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
   - package-ecosystem: "docker"
     directories:
       - "/frontend"
@@ -20,3 +30,7 @@ updates:
       interval: "monthly"
     commit-message:
       prefix: "[docker] "
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"

--- a/.github/workflows/api-code-test.yml
+++ b/.github/workflows/api-code-test.yml
@@ -4,31 +4,35 @@ on:
   pull_request:
     paths:
       - backend/**
+      - .github/workflows/api-code-test.yml
 
 defaults:
   run:
     working-directory: backend
+
+permissions:
+  contents: read
 
 jobs:
   pytest:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.13"
 
       - name: Install Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
         with:
           virtualenvs-create: false
           virtualenvs-in-project: false
           installer-parallel: true
 
-      - name: Valiate poetry.lock
+      - name: Validate poetry.lock
         run: poetry check
 
       - name: Install dependencies
@@ -38,56 +42,66 @@ jobs:
         run: coverage run -m pytest tests
 
       - name: Generate Coverage Report
-        run: coverage report
+        run: |
+          coverage report
+          {
+            echo '## API coverage'
+            echo
+            echo '```'
+            coverage report
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
   pylint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.13"
 
       - name: Install Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
         with:
           virtualenvs-create: false
           virtualenvs-in-project: false
           installer-parallel: true
 
-      - name: Valiate poetry.lock
+      - name: Validate poetry.lock
         run: poetry check
 
       - name: Install dependencies
         run: poetry install --no-interaction
 
-      - name: Test
+      - name: Run pylint
         run: pylint api tests
+
   isort:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.13"
 
       - name: Install Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
         with:
           virtualenvs-create: false
           virtualenvs-in-project: false
           installer-parallel: true
 
-      - name: Valiate poetry.lock
+      - name: Validate poetry.lock
         run: poetry check
 
       - name: Install dependencies
         run: poetry install --no-interaction
 
-      - name: Test
+      - name: Run isort
         run: isort api tests --check-only

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,42 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7 # v2.3.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch and minor
+        if: |
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor' ||
+          steps.meta.outputs.dependency-type == 'security'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Flag major updates for human review
+        if: steps.meta.outputs.update-type == 'version-update:semver-major'
+        run: |
+          gh pr edit "$PR_URL" --add-label "needs-human-review" || true
+          gh pr comment "$PR_URL" --body \
+            "Major version bump for **${{ steps.meta.outputs.dependency-names }}** \
+            (${{ steps.meta.outputs.previous-version }} → ${{ steps.meta.outputs.new-version }}). \
+            Auto-merge skipped; please review."
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,24 @@
+name: Dependency Review
+
+# Fails the PR if a high-severity advisory or disallowed license is introduced.
+# Runs only on PRs because dependency-review-action diffs base..head.
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@67d4f4bd7a9b17a0db54d2a7519187c65e339de8 # v4.5.0
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,0 +1,174 @@
+name: Smoke test
+
+# Builds the prod images from the PR's checkout, brings up the full stack via
+# docker-compose.smoke.yml, runs the API+nginx smoke test, then runs Playwright
+# against the running web container. 
+
+on:
+  pull_request:
+    paths:
+      - backend/**
+      - frontend/**
+      - docker-compose.yml
+      - docker-compose.smoke.yml
+      - scripts/smoke.sh
+      - .github/workflows/smoke-stack.yml
+  push:
+    branches:
+      - devel
+
+permissions:
+  contents: read
+
+env:
+  PKG_DIR: frontend/web
+
+jobs:
+  build-images:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - tag: web
+            context: frontend
+          - tag: api
+            context: backend
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Build ${{ matrix.image.tag }}
+        uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # v6.13.0
+        with:
+          context: ${{ matrix.image.context }}
+          push: false
+          load: true
+          target: ${{ matrix.image.tag }}
+          tags: portcheckerio-${{ matrix.image.tag }}:pr-${{ github.event.pull_request.number || 'push' }}
+          cache-from: type=gha,scope=${{ matrix.image.tag }}
+          cache-to: type=gha,scope=${{ matrix.image.tag }},mode=max
+
+  smoke:
+    needs: build-images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Run compose smoke test
+        run: bash scripts/smoke.sh
+        env:
+          DOCKER_BUILDKIT: "1"
+
+      - name: Capture compose logs on failure
+        if: failure()
+        run: |
+          docker compose -f docker-compose.smoke.yml logs --no-color > compose.log || true
+
+      - name: Upload compose logs
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: compose-logs-smoke
+          path: compose.log
+          if-no-files-found: ignore
+
+      - name: Tear down stack
+        if: always()
+        run: docker compose -f docker-compose.smoke.yml down -v --remove-orphans || true
+
+  browser-tests:
+    needs: build-images
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ env.PKG_DIR }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v6.0.0
+        with:
+          node-version: "25"
+          cache: yarn
+          cache-dependency-path: ${{ env.PKG_DIR }}/yarn.lock
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('frontend/web/yarn.lock') }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: yarn browser-tests:setup
+
+      - name: Install Playwright system deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: yarn playwright install-deps chromium
+
+      - name: Bring up smoke stack
+        working-directory: .
+        run: |
+          docker compose -f docker-compose.smoke.yml up -d --build --wait --wait-timeout 120
+
+      - name: Run browser tests
+        run: yarn browser-tests
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: playwright-report
+          path: |
+            ${{ env.PKG_DIR }}/playwright-report/
+            ${{ env.PKG_DIR }}/test-results/
+          if-no-files-found: ignore
+
+      - name: Capture compose logs on failure
+        if: failure()
+        working-directory: .
+        run: docker compose -f docker-compose.smoke.yml logs --no-color > compose.log || true
+
+      - name: Upload compose logs
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: compose-logs-browser-tests
+          path: compose.log
+          if-no-files-found: ignore
+
+      - name: Tear down stack
+        if: always()
+        working-directory: .
+        run: docker compose -f docker-compose.smoke.yml down -v --remove-orphans || true
+
+  stack-pass:
+    needs: [build-images, smoke, browser-tests]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Verify all jobs passed
+        run: |
+          if [[ "${{ needs.build-images.result }}" != "success" ]] \
+            || [[ "${{ needs.smoke.result }}" != "success" ]] \
+            || [[ "${{ needs.browser-tests.result }}" != "success" ]]; then
+            echo "One or more smoke jobs failed."
+            exit 1
+          fi
+          echo "Smoke pass"

--- a/.github/workflows/web-code-test.yml
+++ b/.github/workflows/web-code-test.yml
@@ -4,10 +4,14 @@ on:
   pull_request:
     paths:
       - frontend/**
+      - .github/workflows/web-code-test.yml
 
 env:
   NODE_VERSION: "25"
   PKG_DIR: "frontend/web"
+
+permissions:
+  contents: read
 
 jobs:
   prettier:
@@ -15,23 +19,18 @@ jobs:
     defaults:
       run:
         working-directory: ${{ env.PKG_DIR }}
-
     steps:
-      - uses: actions/checkout@v4
-
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v6.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: yarn
           cache-dependency-path: ${{ env.PKG_DIR }}/yarn.lock
-
       - name: Enable Corepack
         run: corepack enable
-
       - name: Install dependencies
         run: yarn install --frozen-lockfile
-
       - name: Run Prettier (check only)
         run: yarn prettier
 
@@ -40,23 +39,18 @@ jobs:
     defaults:
       run:
         working-directory: ${{ env.PKG_DIR }}
-
     steps:
-      - uses: actions/checkout@v4
-
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v6.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: yarn
           cache-dependency-path: ${{ env.PKG_DIR }}/yarn.lock
-
       - name: Enable Corepack
         run: corepack enable
-
       - name: Install dependencies
         run: yarn install --frozen-lockfile
-
       - name: Run ESLint
         run: yarn lint --max-warnings=0
 
@@ -65,22 +59,29 @@ jobs:
     defaults:
       run:
         working-directory: ${{ env.PKG_DIR }}
-
     steps:
-      - uses: actions/checkout@v4
-
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v6.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: yarn
           cache-dependency-path: ${{ env.PKG_DIR }}/yarn.lock
-
       - name: Enable Corepack
         run: corepack enable
-
       - name: Install dependencies
         run: yarn install --frozen-lockfile
-
-      - name: Run Jest
-        run: yarn test
+      - name: Run Jest with coverage
+        run: |
+          set -o pipefail
+          yarn test --coverage --coverageReporters=text-summary --coverageReporters=json-summary 2>&1 | tee jest.out
+      - name: Surface coverage in job summary
+        if: always()
+        run: |
+          {
+            echo '## Web coverage'
+            echo
+            echo '```'
+            sed -n '/=* Coverage summary =*/,/=*$/p' jest.out || true
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,9 @@ k8s.yml
 .elasticbeanstalk/*
 !.elasticbeanstalk/*.cfg.yml
 !.elasticbeanstalk/*.global.yml
+
+# Playwright
+frontend/web/test-results/
+frontend/web/playwright-report/
+frontend/web/blob-report/
+frontend/web/.playwright-cache/

--- a/README.md
+++ b/README.md
@@ -78,6 +78,33 @@ $ docker-compose up
 
 portchecker.io front-end will be running at [http://0.0.0.0:8080](http://0.0.0.0:8080) and the API will be running at [http://0.0.0.0:8000](http://0.0.0.0:8000).
 
+## CI smoke & browser tests
+
+CI runs the same checks you'd otherwise do by hand on every PR:
+
+- builds both prod images from the PR's checkout,
+- brings the stack up via `docker-compose.smoke.yml` (which builds `Dockerfile`, not `Dockerfile.dev`, and runs a local `nc` listener so the port-check API can be tested without touching the needing internet),
+- runs `scripts/smoke.sh` against the API and through the nginx proxy,
+- runs a Playwright browser test that submits the form and asserts results render.
+
+To run the smoke locally:
+
+```
+$ bash scripts/smoke.sh
+```
+
+To run the browser tests locally:
+
+```
+$ docker compose -f docker-compose.smoke.yml up -d --build --wait
+$ cd frontend/web
+$ yarn install
+$ yarn browser-tests:setup   # first time only
+$ yarn browser-tests
+```
+
+Dependabot patch, minor, and security updates auto-merge once required checks pass. Major versions are flagged for human review.
+
 ## Environment Variables
 
 The following configuration options are available. These would be set within the Docker compose files, or in your environment if you're using portchecker standalone.

--- a/docker-compose.smoke.yml
+++ b/docker-compose.smoke.yml
@@ -1,0 +1,64 @@
+---
+# Used by scripts/smoke.sh and CI workflows. 
+services:
+  web:
+    image: portcheckerio-web:smoke
+    build:
+      context: frontend
+      dockerfile: Dockerfile
+      target: web
+    container_name: web
+    environment:
+      - DEFAULT_HOST=
+      - DEFAULT_PORT=443
+      - API_URL=http://api:8000
+    ports:
+      - 8080:80
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-S", "http://127.0.0.1"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 5s
+    depends_on:
+      api:
+        condition: service_healthy
+    networks:
+      - portchecker
+
+  api:
+    image: portcheckerio-api:smoke
+    build:
+      context: backend
+      dockerfile: Dockerfile
+      target: api
+    container_name: api
+    environment:
+      # Allow the test sidecar's private IP so the port-check path is
+      # exercised without depending on egress to the public internet.
+      - ALLOW_PRIVATE=true
+    ports:
+      - 8000:8000
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-S", "http://127.0.0.1:8000/healthz"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 5s
+    networks:
+      - portchecker
+
+  # Local listener used by the smoke test to verify the port-check API
+  # against a known-open TCP port without requiring internet.
+  port-target:
+    image: alpine:3.20
+    container_name: port-target
+    command: ["sh", "-c", "nc -lk -p 9999 -e /bin/cat"]
+    networks:
+      portchecker:
+        aliases:
+          - port-target
+
+networks:
+  portchecker:
+    driver: bridge

--- a/frontend/web/browser-tests/checker.spec.js
+++ b/frontend/web/browser-tests/checker.spec.js
@@ -1,0 +1,63 @@
+/* @format */
+// @ts-check
+const { test, expect } = require("@playwright/test");
+
+/**
+ * Browser-driven check against the running smoke stack.
+ *
+ * The smoke compose file pins ALLOW_PRIVATE=true and runs a "port-target"
+ * netcat sidecar listening on 9999, so this submits a real query through the
+ * nginx proxy and asserts the rendered results panel.
+ */
+
+test.describe("port checker UI", () => {
+    test.beforeEach(async ({ page }) => {
+        // The page makes a best-effort GET to https://1.1.1.1/cdn-cgi/trace
+        // to populate the host input. Block it so the test is deterministic
+        // and offline-safe.
+        await page.route("**/cdn-cgi/trace", (route) => route.abort());
+    });
+
+    test("renders the form", async ({ page }) => {
+        await page.goto("/");
+        await expect(page).toHaveTitle(/portchecker/i);
+        await expect(page.locator("#form")).toBeVisible();
+        await expect(page.locator("#host")).toBeVisible();
+        await expect(page.locator("#ports")).toBeVisible();
+    });
+
+    test("submits a query against the port-target sidecar and shows results", async ({ page }) => {
+        await page.goto("/");
+
+        await page.locator("#host").fill("port-target");
+        await page.locator("#ports").fill("9999, 9998");
+
+        await page.locator("#submit").click();
+
+        const results = page.locator("#results");
+        await expect(results).toBeVisible({ timeout: 10_000 });
+        await expect(page.locator("#results-host")).toHaveText("port-target");
+
+        // Both ports rendered.
+        const items = page.locator("#results-list .result-item");
+        await expect(items).toHaveCount(2);
+
+        // 9999 open, 9998 closed.
+        await expect(page.locator("#results-list").getByText("Port 9999")).toBeVisible();
+        await expect(page.locator("#results-list").getByText("Port 9998")).toBeVisible();
+        await expect(page.locator("#results-list .result-status.open")).toHaveCount(1);
+        await expect(page.locator("#results-list .result-status.closed")).toHaveCount(1);
+    });
+
+    test("surfaces a validation error for an out-of-range port", async ({ page }) => {
+        await page.goto("/");
+
+        await page.locator("#host").fill("port-target");
+        await page.locator("#ports").fill("70000");
+        await page.locator("#submit").click();
+
+        // Client-side validation marks the field as invalid before submit fires.
+        await expect(page.locator("#ports").locator("xpath=ancestor::*[contains(@class,'form-group')]"))
+            .toHaveClass(/has-error/);
+    });
+});

--- a/frontend/web/jest.config.js
+++ b/frontend/web/jest.config.js
@@ -3,8 +3,9 @@ module.exports = {
     testEnvironment: "jsdom",
     roots: ["<rootDir>/src"],
     testMatch: ["**/__tests__/**/*.test.js", "**/*.test.js"],
-    testPathIgnorePatterns: ["/node_modules/", "setup.js"],
+    testPathIgnorePatterns: ["/node_modules/", "setup.js", "/browser-tests/"],
     moduleFileExtensions: ["js"],
     setupFilesAfterEnv: ["<rootDir>/src/__tests__/setup.js"],
     verbose: true,
+    collectCoverageFrom: ["src/js/**/*.js", "!src/js/**/*.min.js"],
 };

--- a/frontend/web/package.json
+++ b/frontend/web/package.json
@@ -25,11 +25,15 @@
         "prettier": "prettier src --check",
         "prettier:fix": "npm run prettier -- --write",
         "test": "jest",
-        "test:watch": "jest --watch"
+        "test:watch": "jest --watch",
+        "test:coverage": "jest --coverage",
+        "browser-tests": "playwright test",
+        "browser-tests:setup": "playwright install --with-deps chromium"
     },
     "devDependencies": {
         "@eslint/js": "^10.0.1",
         "copy-webpack-plugin": "^14.0.0",
+        "@playwright/test": "^1.49.0",
         "css-loader": "^7.1.4",
         "css-minimizer-webpack-plugin": "^7.0.2",
         "eslint": "^10.0.2",

--- a/frontend/web/playwright.config.js
+++ b/frontend/web/playwright.config.js
@@ -1,0 +1,30 @@
+/* @format */
+// @ts-check
+const { defineConfig, devices } = require("@playwright/test");
+
+/**
+ * Playwright runs against the running smoke stack (web @ :8080, api @ :8000).
+ * The compose stack is brought up by scripts/smoke.sh in CI before this is invoked.
+ *
+ * For local runs:
+ *   docker compose -f docker-compose.smoke.yml up -d --build
+ *   yarn --cwd frontend/web browser-tests
+ */
+module.exports = defineConfig({
+    testDir: "./browser-tests",
+    timeout: 30_000,
+    expect: { timeout: 5_000 },
+    fullyParallel: true,
+    forbidOnly: !!process.env.CI,
+    retries: process.env.CI ? 1 : 0,
+    workers: process.env.CI ? 1 : undefined,
+    reporter: process.env.CI ? [["github"], ["list"]] : "list",
+    use: {
+        baseURL: process.env.PLAYWRIGHT_BASE_URL || "http://127.0.0.1:8080",
+        trace: "retain-on-failure",
+        screenshot: "only-on-failure",
+    },
+    projects: [
+        { name: "chromium", use: { ...devices["Desktop Chrome"] } },
+    ],
+});

--- a/frontend/web/yarn.lock
+++ b/frontend/web/yarn.lock
@@ -947,6 +947,13 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.2.9.tgz#d229a7b7f9dac167a156992ef23c7f023653f53b"
   integrity sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==
 
+"@playwright/test@^1.49.0":
+  version "1.60.0"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.60.0.tgz#e696c31427e8882851235cd556dc2490c3206d97"
+  integrity sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==
+  dependencies:
+    playwright "1.60.0"
+
 "@sinclair/typebox@^0.34.0":
   version "0.34.47"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.34.47.tgz#61b684d8a20d2890b9f1f7b0d4f76b4b39f5bc0d"
@@ -2963,6 +2970,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 fsevents@^2.3.3, fsevents@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
@@ -4598,6 +4610,20 @@ pkijs@^3.3.3:
     pvtsutils "^1.3.6"
     pvutils "^1.1.3"
     tslib "^2.8.1"
+
+playwright-core@1.60.0:
+  version "1.60.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.60.0.tgz#24e0d9cc4730713db5dffcace29b5e4696b1907a"
+  integrity sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==
+
+playwright@1.60.0:
+  version "1.60.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.60.0.tgz#89710863a51f21112633ef8b6b182594d3bfd7b5"
+  integrity sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==
+  dependencies:
+    playwright-core "1.60.0"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 postcss-calc@^10.1.1:
   version "10.1.1"

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+#
+# Compose-level smoke test:
+# - builds the prod images from this checkout
+# - brings the stack up
+# - hits the API and the nginx proxy
+# - tears everything down unless KEEP_STACK=1
+#
+# Used by CI (.github/workflows/pr-stack.yml) and locally.
+#
+# Usage:
+#   scripts/smoke.sh
+#   KEEP_STACK=1 scripts/smoke.sh
+
+set -Eeuo pipefail
+shopt -s inherit_errexit 2>/dev/null || true
+
+readonly ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly COMPOSE_FILE="${ROOT_DIR}/docker-compose.smoke.yml"
+readonly WEB_URL="http://127.0.0.1:8080"
+readonly API_URL="http://127.0.0.1:8000"
+
+log() {
+  printf '%s\n' "$*"
+}
+
+group_begin() {
+  printf '::group::%s\n' "$*"
+}
+
+group_end() {
+  printf '::endgroup::\n'
+}
+
+fail() {
+  printf 'SMOKE FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "missing required command: $1"
+}
+
+compose() {
+  docker compose -f "$COMPOSE_FILE" "$@"
+}
+
+http_get() {
+  curl -fsS "$1"
+}
+
+http_status() {
+  curl -s -o /dev/null -w '%{http_code}' "$1"
+}
+
+http_post_json() {
+  local url="$1"
+  local payload="$2"
+  curl -fsS -X POST -H 'Content-Type: application/json' -d "$payload" "$url"
+}
+
+expect_eq() {
+  local expected="$1"
+  local actual="$2"
+  local context="$3"
+
+  [[ "$actual" == "$expected" ]] || fail "$context expected '$expected', got: $actual"
+}
+
+expect_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local context="$3"
+
+  grep -Fq "$needle" <<<"$haystack" || fail "$context missing '$needle'"
+}
+
+cleanup() {
+  local status="$1"
+
+  if [[ "${KEEP_STACK:-0}" == "1" ]]; then
+    log "KEEP_STACK=1 set, leaving stack running."
+    exit "$status"
+  fi
+
+  if (( status != 0 )); then
+    group_begin "Compose logs"
+    compose logs --no-color || true
+    group_end
+  fi
+
+  compose down -v --remove-orphans >/dev/null 2>&1 || true
+  exit "$status"
+}
+
+trap 'cleanup $?' EXIT
+
+require_cmd docker
+require_cmd curl
+require_cmd grep
+
+cd "$ROOT_DIR"
+
+group_begin "docker compose build"
+compose build --no-cache
+group_end
+
+group_begin "docker compose up"
+compose up -d --wait --wait-timeout 120
+group_end
+
+log "==> GET /healthz (direct)"
+body="$(http_get "${API_URL}/healthz")"
+expect_eq "true" "$body" "/healthz"
+
+log "==> GET /api/me with do-connecting-ip header"
+body="$(curl -fsS -H 'do-connecting-ip: 203.0.113.7' "${API_URL}/api/me")"
+expect_eq "203.0.113.7" "$body" "/api/me"
+
+log "==> GET /api/{host}/{port} with explicit host (port-target sidecar)"
+body="$(http_get "${API_URL}/api/port-target/9999")"
+expect_eq "True" "$body" "/api/port-target/9999"
+
+log "==> GET /api/{host}/{port} closed port"
+body="$(http_get "${API_URL}/api/port-target/9998")"
+expect_eq "False" "$body" "/api/port-target/9998"
+
+log "==> POST /api/query (mixed open/closed)"
+body="$(http_post_json "${API_URL}/api/query" '{"host":"port-target","ports":[9999,9998]}')"
+log "    body: $body"
+expect_contains "$body" '"port":9999' "POST /api/query"
+expect_contains "$body" '"port":9998' "POST /api/query"
+expect_contains "$body" '"error":false' "POST /api/query"
+expect_contains "$body" '"host":"port-target"' "POST /api/query"
+
+log "==> POST /api/query (invalid port -> 400)"
+status="$(curl -s -o /dev/null -w '%{http_code}' \
+  -X POST -H 'content-type: application/json' \
+  -d '{"host":"port-target","ports":[70000]}' \
+  "${API_URL}/api/query")"
+expect_eq "400" "$status" "POST /api/query invalid port"
+
+log "==> GET /docs"
+status="$(http_status "${API_URL}/docs")"
+expect_eq "200" "$status" "/docs"
+
+log "==> GET /metrics"
+status="$(http_status "${API_URL}/metrics")"
+expect_eq "200" "$status" "/metrics"
+
+log "==> GET / (nginx)"
+body="$(http_get "${WEB_URL}/")"
+expect_contains "$body" 'id="form"' "index.html"
+expect_contains "$body" 'id="host"' "index.html"
+expect_contains "$body" 'id="ports"' "index.html"
+
+log "==> nginx proxies /api/* to the api service"
+body="$(http_get "${WEB_URL}/api/port-target/9999")"
+expect_eq "True" "$body" "proxied /api/port-target/9999"
+
+log "==> nginx proxies /docs"
+status="$(http_status "${WEB_URL}/docs")"
+expect_eq "200" "$status" "proxied /docs"
+
+log
+log "SMOKE PASS"


### PR DESCRIPTION
Our current tests don't really validate the deployed application, so Dependabot PRs still need someone to manually check that the stack actually works. This adds a proper smoke-test pipeline that builds the production images and verifies nginx, config generation, API endpoints, port checks, and the frontend against a running stack.

The new `Smoke` workflow builds both production images on every PR, runs a smoke test suite, and runs a small set of Playwright tests against the application. The goal is that routine dependency updates can merge automatically once CI is green.

While I was here, I also pinned GitHub Actions, added Dependency Review checks, surfaced coverage in job summaries, configured Dependabot auto-merge for patch, minor, and security updates, and reduced Dependabot noise by ignoring regular patch-version update PRs.

Tested locally with:

* `bash scripts/smoke.sh` (12/12 passing)
* `yarn browser-tests` (3/3 passing)

`Smoke / stack-pass` is intended to be the single required check for the pipeline.
